### PR TITLE
Delete Alarms when intent is deleted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /src/windows/**/.vs
 /src/windows/**/bin
 /src/windows/**/obj
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ cordova.plugins.notification.local.requestIgnoreBatteryOptimizations(function (g
 The request method here will work one of two ways.
 1. If you have the REQUEST_IGNORE_BATTERY_OPTIMIZATIONS permission defined in the manifest, it will use ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS to explicitly ignore battery optimizations for this app.  This is the best overall user experience, but the REQUEST_IGNORE_BATTERY_OPTIMIZATIONS permission seems to be frowned upon and can get your app banned. This plugin does not have this permission in plugin.xml for this reason, so you will need to use the cordova-custom-config plugin to add it to your config.xml. Alternatively, you can  use the edit-config tag in the platform section of the config.xml.
 ```xml
-<edit-config file="AndroidManifest.xml" mode="merge" target="/manifest/uses-permission">
+<edit-config file="AndroidManifest.xml" mode="merge" target="/manifest/uses-permission" xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 </edit-config>
 ```

--- a/README.md
+++ b/README.md
@@ -451,7 +451,12 @@ cordova.plugins.notification.local.requestIgnoreBatteryOptimizations(function (g
 ```
 
 The request method here will work one of two ways.
-1. If you have the REQUEST_IGNORE_BATTERY_OPTIMIZATIONS permission defined in the manifest, it will use ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS to explicitly ignore battery optimizations for this app.  This is the best overall user experience, but the REQUEST_IGNORE_BATTERY_OPTIMIZATIONS permission seems to be frowned upon and can get your app banned. This plugin does not have this permission in plugin.xml for this reason, so you will need to use the cordova-custom-config plugin to add it to your config.xml
+1. If you have the REQUEST_IGNORE_BATTERY_OPTIMIZATIONS permission defined in the manifest, it will use ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS to explicitly ignore battery optimizations for this app.  This is the best overall user experience, but the REQUEST_IGNORE_BATTERY_OPTIMIZATIONS permission seems to be frowned upon and can get your app banned. This plugin does not have this permission in plugin.xml for this reason, so you will need to use the cordova-custom-config plugin to add it to your config.xml. Alternatively, you can  use the edit-config tag in the platform section of the config.xml.
+```xml
+<edit-config file="AndroidManifest.xml" mode="merge" target="/manifest/uses-permission">
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+</edit-config>
+```
 2. If you do not have REQUEST_IGNORE_BATTERY_OPTIMIZATIONS requested, it will launch ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS to show a list of all applications.  You will want to put some sort of instructions prior to this to walk the user through this.  Also, this action doesn't exist on all Android devices (is missing on Samsung phones), which will make this method simply return false if it can't start the activity.
 
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-local-notification"
-        version="0.9.0-beta.4">
+        version="0.9.0-beta.5">
 
     <name>LocalNotification</name>
 

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
+import de.appplant.cordova.plugin.localnotification.TriggerReceiver;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -96,6 +97,9 @@ public final class Notification {
 
     // Builder with full configuration
     private final NotificationCompat.Builder builder;
+
+    // Receiver to handle the trigger event
+    private Class<?> receiver = TriggerReceiver.class;
 
     /**
      * Constructor
@@ -184,6 +188,8 @@ public final class Notification {
         List<Pair<Date, Intent>> intents = new ArrayList<Pair<Date, Intent>>();
         Set<String> ids                  = new ArraySet<String>();
         AlarmManager mgr                 = getAlarmMgr();
+        
+        this.receiver = receiver;
 
         cancelScheduledAlarms();
 
@@ -311,7 +317,8 @@ public final class Notification {
             return;
 
         for (String action : actions) {
-            Intent intent = new Intent(action);
+            Intent intent = new Intent(context, this.receiver)
+                    .setAction(action);
 
             PendingIntent pi = PendingIntent.getBroadcast(
                     context, 0, intent, 0);
@@ -348,6 +355,8 @@ public final class Notification {
         mergeJSONObjects(updates);
         persist(null);
 
+        this.receiver = receiver;
+        
         if (getType() != Type.TRIGGERED)
             return;
 

--- a/www/local-notification.js
+++ b/www/local-notification.js
@@ -638,7 +638,7 @@ exports._mergeWithDefaults = function (options) {
 
     options.meta = {
         plugin:  'cordova-plugin-local-notification',
-        version: '0.9-beta.4'
+        version: '0.9-beta.5'
     };
 
     return options;


### PR DESCRIPTION
I took the changes from this pull request fix:katzer/cordova-plugin-local-notifications#1873 as I was still seeing too many alarms. The limit of 500 alarms also exists on Xiaomi devices.